### PR TITLE
✨ Add support for installing dependencies using yarn

### DIFF
--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -29,6 +29,9 @@ grep " node-v${NODE_VERSION}-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum 
 tar -zxf node-v${NODE_VERSION}-linux-x64.tar.gz -C /usr/local --strip-components=1
 npm install -g npm@${NPM_VERSION} -s &>/dev/null
 
+# Install yarn
+npm install -g yarn -s &>/dev/null
+
 # Delete NPM things that we don't really need (like tests) from node_modules
 find /usr/local/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf 
 

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -53,7 +53,14 @@ if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
 fi
 
 echo "---> Building your Node application from source"
-npm install -s
+
+if [ ! -z "$YARN_ENABLED" ]; then
+	echo "---> Using 'yarn install' with YARN_ARGS"
+	yarn install $YARN_ARGS
+else
+	echo "---> Using 'npm install'"
+	npm install -s
+fi
 
 # Fix source directory permissions
 # fix-permissions ./


### PR DESCRIPTION
There are 2 changes in this:
* yarn is installed globally in the docker image
* yarn will be used to install dependencies depending on an env var
value

A built version of the image is published to https://hub.docker.com/r/davidmartin/centos7-s2i-nodejs-yarn/
with some instructions on how it can be used.
e.g.
```
s2i build -e "YARN_ENABLED=true" git@github.com:david-martin/nodejs-ex davidmartin/centos7-s2i-nodejs-yarn:latest myapp
```

There are 2 environment variables available
* `YARN_ENABLED` - If set, will use `yarn install` instead of `npm install`
* `YARN_ARGS` - Will be passed to `yarn install` if `YARN_ENABLED` is set