### PR TITLE
doc: replace versions info with link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,7 @@ official [OpenShift Documentation](https://docs.openshift.org/latest/using_image
 
 ## Versions
 
-Node.js versions [currently provided](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/):
-
-<!-- versions.start -->
-* **`9.4.0`**: (9.x, latest)
-* **`8.9.4`**: (8.x, Carbon)
-* **`7.10.1`**: (7.x)
-* **`6.11.4`**: (6.x, Boron)
-* **`5.12.0`**: (5.x)
-* **`4.8.4`**: (4.x, Argon)
-<!-- versions.end -->
+Node.js versions [currently provided](https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs):
 
 ## Usage
 


### PR DESCRIPTION
This commit removes the version information and replaces it with a link
to docker hub where we can maintain the version information in a single
place.