### PR TITLE
build: update git to 2.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ COPY ./s2i/ $STI_SCRIPTS_PATH
 COPY ./contrib/ /opt/app-root
 
 RUN /opt/app-root/etc/install_node.sh
+RUN /usr/bin/scl enable rh-git29 true
 
 USER 1001
 
+ENTRYPOINT ["/usr/bin/scl", "enable", "rh-git29", "--"]
 # Set the default CMD to print the usage
-CMD ${STI_SCRIPTS_PATH}/usage
+CMD ["/usr/bin/scl", "enable", "rh-git29", "${STI_SCRIPTS_PATH}/usage"]

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+yum install -y centos-release-scl
+yum install -y rh-git29
+scl enable rh-git29 bash
+
 # Ensure git uses https instead of ssh for NPM install
 # See: https://github.com/npm/npm/issues/5257
 echo -e "Setting git config rules"

--- a/s2i/run
+++ b/s2i/run
@@ -12,6 +12,10 @@ else
   set -x
 fi
 
+export GIT_COMMITTER_NAME="unknown"
+export and GIT_COMMITTER_EMAIL="unknown@localhost.com"
+git --version
+
 # Runs the nodejs application server.
 run_node() {
   echo -e "Environment: \n\tDEV_MODE=${DEV_MODE}\n\tNODE_ENV=${NODE_ENV}\n\tDEBUG_PORT=${DEBUG_PORT}"


### PR DESCRIPTION
This commit updates git to 2.9.3 to avoid an issue where git clone would
fail when running in openshift with the following error:
```console
fatal: unable to look up current user in the passwd file: no such user
```
Refs: http://git.661346.n2.nabble.com/git-clone-fails-when-current-user-is-not-in-etc-passwd-td7643604.html