### PR TITLE
Merging of RHOAR and RHSCL into a single 'nodejs' imagestream

### DIFF
--- a/imagestreams/nodejs-rhel7.json
+++ b/imagestreams/nodejs-rhel7.json
@@ -1,0 +1,131 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nodejs",
+    "annotations": {
+      "openshift.io/display-name": "Node.js"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Node.js (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major versions updates.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "supports":"nodejs",
+          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "0.10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 0.10",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "DEPRECATED: Build and run Node.js 0.10 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/0.10/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "hidden,nodejs",
+          "supports":"nodejs:0.10,nodejs:0.1,nodejs",
+          "version": "0.10",
+          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "4",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 4",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 4 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/4/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "hidden,builder,nodejs",
+          "supports":"nodejs:4,nodejs",
+          "version": "4",
+          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "6",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 6",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 6 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "supports":"nodejs:6,nodejs",
+          "version": "6",
+          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhscl/nodejs-6-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 8",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "8",
+          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhscl/nodejs-8-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "8-RHOAR",
+        "annotations": {
+          "openshift.io/display-name": "OpenShift Application Runtimes Node.js 8",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/bucharest-gold/centos7-s2i-nodejs.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "8",
+          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Just introducing a new 8-RHOAR tag. Think this is the best we
can do at the moment. It will be harder to introduce a new imagestream
name like rhoar-nodejs and then move to just 'nodejs'. I'd like to
start with what we want it to be. Also need to merge, since RHSCL also
has '6' and '4'. Perhaps we can just swap out the '8' tag later for
just RHOAR.

@bparees @lance I think this is the way we should go forward. 1 entry in the catalog with multiple tags. We can phase out the tags. We can update library to just pull in this 1 nodejs imagestream definition.