### PR TITLE
remove scl usage and link git instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,8 @@ COPY ./s2i/ $STI_SCRIPTS_PATH
 COPY ./contrib/ /opt/app-root
 
 RUN /opt/app-root/etc/install_node.sh
-RUN /usr/bin/scl enable rh-git29 true
 
 USER 1001
 
-ENTRYPOINT ["/usr/bin/scl", "enable", "rh-git29", "--"]
 # Set the default CMD to print the usage
-CMD ["/usr/bin/scl", "enable", "rh-git29", "${STI_SCRIPTS_PATH}/usage"]
+CMD ${STI_SCRIPTS_PATH}/usage

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -4,7 +4,7 @@ set -ex
 
 yum install -y centos-release-scl
 yum install -y rh-git29
-scl enable rh-git29 bash
+ln -fs /opt/rh/rh-git29/root/usr/bin/git /usr/bin/git
 
 # Ensure git uses https instead of ssh for NPM install
 # See: https://github.com/npm/npm/issues/5257

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "nodemon --ignore node_modules/ server.js",
     "postinstall": "tsc greeting.ts && node-gyp -C addon configure build",
-    "start": "echo 'starting node app' && node server.js"
+    "start": "node server.js"
   },
   "devDependencies": {
     "tape": "*"

--- a/test/test-app/server.js
+++ b/test/test-app/server.js
@@ -8,6 +8,11 @@ const os = require('os');
 const port = process.env.PORT || process.env.port || process.env.OPENSHIFT_NODEJS_PORT || 8080;
 const ip = process.env.OPENSHIFT_NODEJS_IP || '0.0.0.0';
 
+process.on('SIGTERM', function(signal) {
+  console.log('Server recieved SIGTERM');
+  process.exit(222);
+});
+
 let nodeEnv = process.env.NODE_ENV || 'unknown';
 
 const server = http.createServer((req, res) => {


### PR DESCRIPTION
This commit removes the usage of scl enable and insteads links the git
version in the image. Using scl enable cause an issue where the npm
process was not running as process 1 and signals got ignored.

Refs: https://github.com/bucharest-gold/centos7-s2i-nodejs/issues/84