### PR TITLE
test: add NPM_CONFIG_TARBALL check

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -135,16 +135,31 @@ test_connection() {
   return $result
 }
 
+test_builder_node_version() {
+  local run_cmd="node --version"
+  local expected_version="v${NODE_VERSION}"
+
+  echo "Checking nodejs runtime version ..."
+  out=$(docker run ${BUILDER} /bin/bash -c "${run_cmd}")
+  if ! echo "${out}" | grep -q "${expected_version}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected_version}', got '${out}'"
+    return 1
+  fi
+
+  echo "Checking NPM_CONFIG_TARBALL environment variable"
+  out=$(docker run ${BUILDER} /bin/bash -c 'echo $NPM_CONFIG_TARBALL')
+  local expected_var="/usr/share/node/node-v${NODE_VERSION}-headers.tar.gz"
+  if ! echo "${out}" | grep -q "${expected_var}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected_var}', got '${out}'"
+    return 1
+  fi
+}
+
 test_node_version() {
   local run_cmd="node --version"
   local expected="v${NODE_VERSION}"
 
   echo "Checking nodejs runtime version ..."
-  out=$(docker run ${BUILDER} /bin/bash -c "${run_cmd}")
-  if ! echo "${out}" | grep -q "${expected}"; then
-    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
-    return 1
-  fi
   out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -231,9 +246,12 @@ url.https://github.com.insteadof=ssh://git@github.com"
   fi
 }
 
+prepare
+test_builder_node_version
+check_result $?
+
 # Build the application image twice to ensure the 'save-artifacts' and
 # 'restore-artifacts' scripts are working properly
-prepare
 run_s2i_build
 check_result $?
 


### PR DESCRIPTION
This commit adds a check to verify that the environment variable
`NPM_CONFIG_TARBALL` matches the target node version.
It also moves the check of the node version of the base image to the
start of the test to allow for early failure if the version don't match.
