### PR TITLE
s2i: use fix-permssions script from s2i core image

### DIFF
--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -27,12 +27,8 @@ if [ ! -h /usr/bin/npx ] ; then
   ln -s /usr/lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx
 fi
 
-# Make /opt/app-root owned by user 1001
-chown -R 1001:0 /opt/app-root
-chmod -R ug+rwx /opt/app-root
-
-# Fix permissions for the npm update-notifier
-chmod -R 777 /opt/app-root/src/.config
+echo "---> Setting directory write permissions"
+fix-permissions /opt/app-root
 
 # Delete NPM things that we don't really need (like tests) from node_modules
 find /usr/local/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -8,7 +8,8 @@ if [ "$DEV_MODE" == true ] ; then
 	set -x
 fi
 
-chmod 775 -R /tmp/src/.
+# echo "---> Setting directory write permissions"
+# fix-permissions /opt/app-root
 
 echo "---> Installing application source"
 cp -Rfp /tmp/src/. ./
@@ -42,6 +43,7 @@ fi
 echo "---> Building your Node application from source"
 echo -e "Current git config"
 git config --list
+
 if [ ! -z "$YARN_ENABLED" ]; then
 	echo "---> Using 'yarn install' with YARN_ARGS"
 	yarn install $YARN_ARGS
@@ -54,8 +56,7 @@ else
 		echo "---> Using 'npm install -s --only=production'"
 		npm install -s --only=production
 	fi
-	echo "---> Cleaning up npm cache"
-	rm -rf .npm
-	echo "---> Setting directory write permissions"
-	exec chmod -R g+rw .
 fi
+
+echo "---> Cleaning up npm cache"
+rm -rf .npm


### PR DESCRIPTION
Replace the various chmod and chgrp commands with a script from
Red Hat Software Collections that does all of this for us.

See: https://github.com/bucharest-gold/centos7-s2i-nodejs/issues/122

This fixes one part of the issue referenced above.