### PR TITLE
s2i: install nss_wrapper & generate-container-user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 # This image provides a Node.JS environment you can use to run your
 # Node.JS applications.
 

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 set -ex
+INSTALL_PKGS="centos-release-scl nss_wrapper rh-git29"
 
-yum install -y centos-release-scl
-yum install -y rh-git29
+yum remove -y rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon
+
+yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS
 ln -fs /opt/rh/rh-git29/root/usr/bin/git /usr/bin/git
 
 # Ensure git uses https instead of ssh for NPM install
@@ -15,9 +17,11 @@ git config --system url."https://".insteadOf git://
 git config --system url."https://".insteadOf ssh://
 git config --list
 
-yum install -y --setopt=tsflags=nodocs openssl
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/rhoar-nodejs-${NODE_VERSION}-1.el7.centos.x86_64.rpm
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/npm-${NPM_VERSION}-1.${NODE_VERSION}.1.el7.centos.x86_64.rpm
+
+rpm -V $INSTALL_PKGS
+yum clean all -y
 
 # Install yarn
 npm install -g yarn -s &>/dev/null

--- a/s2i/generate-container-user
+++ b/s2i/generate-container-user
@@ -1,0 +1,19 @@
+# Set current user in nss_wrapper
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+
+    NSS_WRAPPER_PASSWD=/opt/app-root/etc/passwd
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cat /etc/passwd | sed -e 's/^default:/builder:/' > $NSS_WRAPPER_PASSWD
+
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=libnss_wrapper.so
+    export LD_PRELOAD
+fi

--- a/s2i/run
+++ b/s2i/run
@@ -1,8 +1,8 @@
 #!/bin/bash
-
 set -e
 
 source /usr/libexec/s2i/env
+source /usr/libexec/s2i/generate-container-user
 
 # Set the environment for this build configuration to production by default.
 if [ "$NODE_ENV" == "production" ]; then


### PR DESCRIPTION
This change brings the image more inline with the existing
Node.js images from SCL.

See: https://github.com/bucharest-gold/centos7-s2i-nodejs/issues/122