### PR TITLE
build: install debuginfo

### DIFF
--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -19,6 +19,8 @@ git config --list
 
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/rhoar-nodejs-${NODE_VERSION}-1.el7.centos.x86_64.rpm
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/npm-${NPM_VERSION}-1.${NODE_VERSION}.1.el7.centos.x86_64.rpm
+yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/rhoar-nodejs-debuginfo-${NODE_VERSION}-1.el7.centos.x86_64.rpm
+fix-permissions /usr/lib/debug
 
 rpm -V $INSTALL_PKGS
 yum clean all -y


### PR DESCRIPTION
This commit installs debuginfo to allow a user to be able use gdb and
have symbols found. This is not perfect as the binary is still built
with optimizations but often this will go a long way.

To verify that this works follow these steps:
```console
$ make build
$ docker run -ti bucharest/centos7-s2i-nodejs:10.x /bin/bash
bash-4.2$ gdb --args node -p 'process.versions'
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-110.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /usr/bin/node...Reading symbols from /usr/lib/debug/usr/bin/node.debug...done.
done.
```