### PR TITLE
build: remove debuginfo

### DIFF
--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -19,8 +19,6 @@ git config --list
 
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/rhoar-nodejs-${NODE_VERSION}-1.el7.centos.x86_64.rpm
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/npm-${NPM_VERSION}-1.${NODE_VERSION}.1.el7.centos.x86_64.rpm
-yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}/rhoar-nodejs-debuginfo-${NODE_VERSION}-1.el7.centos.x86_64.rpm
-fix-permissions /usr/lib/debug
 
 rpm -V $INSTALL_PKGS
 yum clean all -y


### PR DESCRIPTION
This commit removes the installation of debuginfo due to the substantial
size increase it caused.

This can be verified manually by:
```console
$ make build
$ docker run -ti bucharestgold/centos7-s2i-nodejs:10.x /bin/bash
bash-4.2$ rpm -qa | grep node
rhoar-nodejs-10.11.0-1.el7.centos.x86_64
rh-nodejs8-runtime-3.0-3.el7.x86_64
```
There should only be the two above and no debuginfo.