### PR TITLE
OKD rebranding and sclorg move for centos7-s2i-nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ to `/opt/app-root/src`, where the source code for your application is located.
 ### Using OpenShift's rsync
 
 If you have deployed your application to OpenShift, you can use
-[oc rsync](https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html) to copy local
+[oc rsync](https://docs.okd.io/latest/dev_guide/copy_files_to_container.html) to copy local
 files to a remote container running in an OpenShift pod.

--- a/imagestreams/nodejs-centos7.json
+++ b/imagestreams/nodejs-centos7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,nodejs",
           "supports":"nodejs:0.10,nodejs:0.1,nodejs",
           "version": "0.10",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,nodejs",
           "supports":"nodejs:4,nodejs",
           "version": "4",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,nodejs",
           "supports":"nodejs:6,nodejs",
           "version": "6",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -97,7 +97,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "8",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -116,7 +116,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "8",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -135,7 +135,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "10",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/nodejs-rhel7.json
+++ b/imagestreams/nodejs-rhel7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,nodejs",
           "supports":"nodejs:0.10,nodejs:0.1,nodejs",
           "version": "0.10",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,nodejs",
           "supports":"nodejs:4,nodejs",
           "version": "4",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,nodejs",
           "supports":"nodejs:6,nodejs",
           "version": "6",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -97,7 +97,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "8",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -116,7 +116,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "8",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -135,7 +135,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "10",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",


### PR DESCRIPTION
docs.openshift.org to docs.okd.io
github.com/openshift/nodejs-ex to github.com/sclorg/nodejs-ex