### PR TITLE
chore: Improve the way a npm build script is found.

### DIFF
--- a/s2i/assemble
+++ b/s2i/assemble
@@ -54,23 +54,23 @@ else
 		echo "---> Building in development mode"
 		npm run build --if-present
 	else
-		echo "---> Using 'npm install -s --only=production'"
-		npm install -s --only=production
-
 		HAS_BUILD=$(node -e "console.log(require('./package.json').scripts.build ? true : false)")
 
 		# check to see if there is a build script by inspecting the package.json
 		if [ "$HAS_BUILD" == true ]; then
 			# Do a npm install to get the dev depdencies
 			echo "---> Installing dev dependencies"
-			npm install
+			NODE_ENV=development npm install
 			#do not fail when there is no build script
 			echo "---> Building in production mode"
 			npm run build --if-present
-
-			echo "---> Pruning the development dependencies"
-			npm prune
+		else
+			echo "---> Using 'npm install -s --only=production'"
+			npm install -s --only=production
 		fi
+
+		echo "---> Pruning the development dependencies"
+		npm prune
 	fi
 fi
 

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -49,16 +49,28 @@ else
 	if [ "$DEV_MODE" == true ]; then
 		echo "---> Using 'npm install'"
 		npm install
-	else
-		echo "---> Installing all dependencies"
-		NODE_ENV=development npm install
 
 		#do not fail when there is no build script
-		echo "---> Building in production mode"
+		echo "---> Building in development mode"
 		npm run build --if-present
+	else
+		echo "---> Using 'npm install -s --only=production'"
+		npm install -s --only=production
 
-		echo "---> Pruning the development dependencies"
-		npm prune
+		HAS_BUILD=$(node -e "console.log(require('./package.json').scripts.build ? true : false)")
+
+		# check to see if there is a build script by inspecting the package.json
+		if [ "$HAS_BUILD" == true ]; then
+			# Do a npm install to get the dev depdencies
+			echo "---> Installing dev dependencies"
+			npm install
+			#do not fail when there is no build script
+			echo "---> Building in production mode"
+			npm run build --if-present
+
+			echo "---> Pruning the development dependencies"
+			npm prune
+		fi
 	fi
 fi
 


### PR DESCRIPTION
* This commit will first install just the production-only dependencies. Then a script
will check the package.json for a build script.  If non is found, it just continues, but
if there is a build script, `npm install` will be called again to install the dev dependencies.
Then `npm run build` is execute.

* This reason for doing this way was so we weren't installing all dependecies if we didn't need them


At first i thought we could use something like [jq](https://stedolan.github.io/jq/) to inspect the package.json, but we would have to install that library. Then i realized we could just use node instead, since it is already installed


This should probably also go into the 10.x and 8.x branches 

connects to #149 